### PR TITLE
Adding a security policy and a bug report template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,28 @@ If you create a pull request please wait for approval from at least one other
 contributor before merging. You should do that merge yourself, as it will
 prove to everyone that you have signed the contributor agreement and thus have
 the merge permission.
+
+
+## Contributing bug reports
+
+Here's how you get help most effectively:
+
+* Before filing a bug report, make sure you can reproduce the issue on a plain
+  vanilla Zope installation. If you cannot, then it's probably not a Zope bug.
+
+* Please provide as many details as possible, such as...
+
+  * Zope version
+  * Python version
+  * Operating system
+
+* It's helpful to describe bugs in terms of expected and actual outcomes, that
+  makes it easier to follow along and reproduce it: In the Zope ZMI I was
+  clicking on the Interfaces tab of a DTML Method, and instead of seeing the
+  Interfaces tab I saw the following error output: ...
+
+* If the developers need more information and follow up with questions, please
+  make sure to answer in a timely manner, especially if the issue report is
+  marked with the feedback required tag. If we don't hear from you after 2-3
+  weeks the issue may be closed.
+

--- a/ISSUE_TEMPLATE/bugreport.md
+++ b/ISSUE_TEMPLATE/bugreport.md
@@ -15,10 +15,6 @@ The best reproductions are in plain Zope installations without addons or at leas
 
 -->
 
-### Version information
-
-<!-- Enter Python and Zope versions you are using -->
-
 ### What I did:
 
 <!-- Enter a reproducible description, including preconditions. -->
@@ -27,5 +23,6 @@ The best reproductions are in plain Zope installations without addons or at leas
 
 ### What actually happened:
 
-### What version of Zope/Addons I am using:
+### What version of Python and Zope/Addons I am using:
 
+<!-- Enter Python and Zope versions you are using -->

--- a/ISSUE_TEMPLATE/bugreport.md
+++ b/ISSUE_TEMPLATE/bugreport.md
@@ -1,0 +1,27 @@
+---
+name: 🐛 Bug Report
+about: If something isn't working as expected.
+
+---
+
+## BUG/PROBLEM REPORT (OR OTHER COMMON ISSUE)
+
+<!--
+
+Please do not report security-related issues here. Report them by email to security@plone.org. The Security Team will contact the relevant maintainer if necessary.
+
+Include tracebacks, screenshots, code of debugging sessions or code that reproduces the issue if possible.
+The best reproductions are in plain Zope installations without addons or at least with minimal needed addons installed.
+
+-->
+
+### What I did:
+
+<!-- Enter a reproducible description, including preconditions. -->
+
+### What I expect to happen:
+
+### What actually happened:
+
+### What version of Plone/ Addons I am using:
+

--- a/ISSUE_TEMPLATE/bugreport.md
+++ b/ISSUE_TEMPLATE/bugreport.md
@@ -15,6 +15,10 @@ The best reproductions are in plain Zope installations without addons or at leas
 
 -->
 
+### Version information
+
+<!-- Enter Python and Zope versions you are using -->
+
 ### What I did:
 
 <!-- Enter a reproducible description, including preconditions. -->
@@ -23,5 +27,5 @@ The best reproductions are in plain Zope installations without addons or at leas
 
 ### What actually happened:
 
-### What version of Plone/ Addons I am using:
+### What version of Zope/Addons I am using:
 

--- a/README.md
+++ b/README.md
@@ -4,4 +4,9 @@ Templates used for all repos which do not provide these files
 * The file ``CONTRIBUTING.md`` from this repository is used for every
   zopefoundation repository which does not have its own version.
 
+* ``SECURITY.md`` contains information on how to file security-related bugs
+
+* Files in the ``ISSUE_TEMPLATE`` folder are used as templates when
+  creating a bug tracker issue
+
 Documentation see https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-default-community-health-file

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+## Security-Related Bugs
+
+DO NOT POST SECURITY-RELATED BUGS IN PUBLIC MAILING LISTS OR DISCUSSION FORUMS.
+
+Security-related bugs should be reported only via email to security@plone.org. Security issues in Zope, Plone or its add-ons can be reported this way, and the Security Team will contact the relevant maintainer if necessary.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 DO NOT POST SECURITY-RELATED BUGS IN PUBLIC MAILING LISTS OR DISCUSSION FORUMS.
 
-Security-related bugs should be reported only via email to security@plone.org. Security issues in Zope, Plone or its add-ons can be reported this way, and the Security Team will contact the relevant maintainer if necessary.
+Security-related bugs should be reported only via email to <security@plone.org>. Security issues in Zope, Plone or its add-ons can be reported this way, and the Security Team will contact the relevant maintainer if necessary.


### PR DESCRIPTION
Fixes #3 

This PR contains a simple security policy file and a bug report issue template.

(I believe) the security policy will be shown when clicking into the top navigation "Security" link in the repository, and apparently it is also shown when people create new issues.

The bug report issue template is adapted from the template used for Products.CMFPlone.